### PR TITLE
add Bookcopies for existing book.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,7 +37,7 @@
             "scripts": [
               "bootstrap/dist/js/bootstrap.min.js",
               "bootstrap/dist/js/bootstrap.bundle.min.js",
-              "@popperjs/core/dist/umd/popper.min.js"
+              "node_modules/@popperjs/core/dist/umd/popper.min.js"
             ]
           },
           "configurations": {

--- a/src/app/add-copies/add-copies.component.html
+++ b/src/app/add-copies/add-copies.component.html
@@ -1,0 +1,120 @@
+<button
+  type="button"
+  class="btn btn-primary"
+  data-bs-toggle="modal"
+  data-bs-target="#addCopiesModal"
+>
+  + Exemplaren
+</button>
+
+<!-- Modal -->
+<div
+  class="modal fade"
+  data-bs-backdrop="static"
+  data-bs-keyboard="false"
+  id="addCopiesModal"
+  tabindex="-1"
+  aria-labelledby="addCopiesLabel"
+  aria-hidden="true"
+>
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="addCopiesLabel">
+          Exemplaren toevoegen
+        </h1>
+        <button
+          type="button"
+          #closeModal
+          class="btn-close"
+          data-bs-dismiss="modal"
+          aria-label="Close"
+          (click)="resetForm()"
+        ></button>
+      </div>
+      <div class="modal-body">
+        <form [formGroup]="addCopiesForm">
+          <label for="nrCopies">Exemplaren toevoegen</label><br />
+          <div class="input-group mb-3">
+            <input
+              type="number"
+              formControlName="nrCopies"
+              class="form-control"
+              placeholder="Aantal exemplaren"
+              aria-describedby="button-addon2"
+            />
+            <button
+              class="btn btn-outline-secondary"
+              type="button"
+              id="button-addon2"
+              (click)="addCopies(addCopiesForm.value.nrCopies)"
+            >
+              Toevoegen
+            </button>
+          </div>
+          <div *ngFor="let state of states.controls; let j = index">
+            <label for="bookCopy">Exemplaar {{ j + 1 }}</label>
+            <div formArrayName="states" class="input-group mb-3">
+              <select
+                [formControlName]="j"
+                class="form-control"
+                id="bookCopy"
+              >
+              <option value="Nieuw">Nieuw</option>
+              <option value="Goed">Goed</option>
+              <option value="Gemiddeld">Gemiddeld</option>
+              <option value="Slecht">Slecht</option>
+              <option value="Onbruikbaar">Onbruikbaar</option>
+            </select>
+              <div class="input-group-append">
+                <button
+                  class="btn btn-outline-secondary"
+                  id="minus"
+                  type="button"
+                  (click)="removeCopy(j)"
+                >
+                  -
+                </button>
+              </div>
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" (click)="resetForm()">
+          Cancel
+        </button>
+        <button
+          [disabled]="addCopiesForm.invalid"
+          type="button"
+          class="btn btn-primary"
+          (click)="onSubmit()"
+        >
+          Opslaan
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<button type="button" #openModal class="btn btn-primary invisible" data-bs-toggle="modal" data-bs-target="#confirmModal">
+</button>
+
+<div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="exampleModalLabel">Toegevoegd</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div *ngFor="let bookcopy of bookCopyList">
+          <h5>Exemplaar {{bookcopy.wtid}}     Conditie: {{bookcopy.state}}</h5>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">OK</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/add-copies/add-copies.component.html
+++ b/src/app/add-copies/add-copies.component.html
@@ -60,11 +60,11 @@
                 class="form-control"
                 id="bookCopy"
               >
-              <option value="Nieuw">Nieuw</option>
-              <option value="Goed">Goed</option>
-              <option value="Gemiddeld">Gemiddeld</option>
-              <option value="Slecht">Slecht</option>
-              <option value="Onbruikbaar">Onbruikbaar</option>
+              <option value="NIEUW">Nieuw</option>
+              <option value="GOED">Goed</option>
+              <option value="GEMIDDELD">Gemiddeld</option>
+              <option value="SLECHT">Slecht</option>
+              <option value="ONBRUIKBAAR">Onbruikbaar</option>
             </select>
               <div class="input-group-append">
                 <button

--- a/src/app/add-copies/add-copies.component.html
+++ b/src/app/add-copies/add-copies.component.html
@@ -2,7 +2,7 @@
   type="button"
   class="btn btn-primary"
   data-bs-toggle="modal"
-  data-bs-target="#addCopiesModal"
+  [attr.data-bs-target]="'#' + bookAddCopy?.id"
 >
   + Exemplaren
 </button>
@@ -12,7 +12,7 @@
   class="modal fade"
   data-bs-backdrop="static"
   data-bs-keyboard="false"
-  id="addCopiesModal"
+  [id]="bookAddCopy?.id"
   tabindex="-1"
   aria-labelledby="addCopiesLabel"
   aria-hidden="true"
@@ -97,10 +97,10 @@
   </div>
 </div>
 
-<button type="button" #openModal class="btn btn-primary invisible" data-bs-toggle="modal" data-bs-target="#confirmModal">
+<button type="button" #openModal class="btn btn-primary invisible" data-bs-toggle="modal" [attr.data-bs-target]="'#confirmModal'+ bookAddCopy?.id">
 </button>
 
-<div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" [id]="'confirmModal'+ bookAddCopy?.id" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/src/app/add-copies/add-copies.component.scss
+++ b/src/app/add-copies/add-copies.component.scss
@@ -1,0 +1,7 @@
+#minus {
+    width: 40px;
+    background-color: rgb(248, 68, 68);
+    font-size: large;
+    font-weight: bold;
+    color: white;
+}

--- a/src/app/add-copies/add-copies.component.spec.ts
+++ b/src/app/add-copies/add-copies.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddCopiesComponent } from './add-copies.component';
+
+describe('AddCopiesComponent', () => {
+  let component: AddCopiesComponent;
+  let fixture: ComponentFixture<AddCopiesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddCopiesComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(AddCopiesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/add-copies/add-copies.component.ts
+++ b/src/app/add-copies/add-copies.component.ts
@@ -4,17 +4,20 @@ import { CommonModule } from '@angular/common';
 import { BookCopyService } from '../bookCopy.service';
 import { ReadBookDto } from '../../dto/ReadBookDto';
 import { ReadBookCopyDto } from '../../dto/ReadBookCopyDto';
+import { BookComponent } from '../book/book.component';
+import { CatalogueComponent } from '../catalogue/catalogue.component';
 
 @Component({
   selector: 'app-add-copies',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, BookComponent, CatalogueComponent],
   templateUrl: './add-copies.component.html',
   styleUrl: './add-copies.component.scss'
 })
 export class AddCopiesComponent {
 
   @Input() bookAddCopy: ReadBookDto | null = null;
+
   @ViewChild('closeModal') closeModal?: ElementRef;
   @ViewChild('openModal') openModal?: ElementRef;
   addCopiesForm: FormGroup;

--- a/src/app/add-copies/add-copies.component.ts
+++ b/src/app/add-copies/add-copies.component.ts
@@ -14,7 +14,7 @@ import { ReadBookCopyDto } from '../../dto/ReadBookCopyDto';
 })
 export class AddCopiesComponent {
 
-  @Input() book: ReadBookDto | null = null;
+  @Input() bookAddCopy: ReadBookDto | null = null;
   @ViewChild('closeModal') closeModal?: ElementRef;
   @ViewChild('openModal') openModal?: ElementRef;
   addCopiesForm: FormGroup;
@@ -29,7 +29,7 @@ export class AddCopiesComponent {
 
   addCopies(nrCopies: number) {
     for (let i = 0; i < nrCopies; i++) {
-      this.states.push(this.formBuilder.control('Nieuw', Validators.required));
+      this.states.push(this.formBuilder.control('NIEUW', Validators.required));
     }
   }
 
@@ -45,11 +45,12 @@ export class AddCopiesComponent {
   onSubmit(): void {
     let dto = {
       states:  this.states.value,
-      bookId: this.book?.id
+      bookId: this.bookAddCopy?.id
     }
 
-    if(confirm("Weet je zeker dat je " + this.states.length + " exemplaren van het boek: '" + this.book?.title + "' wilt toevoegen?")) {
+    if(confirm("Weet je zeker dat je " + this.states.length + " exemplaren van het boek: '" + this.bookAddCopy?.title + "' wilt toevoegen?")) {
       this.bookCopyService.createBookCopy(dto).subscribe(response => {
+        console.log("request", dto);
         // Dit wordt uitgevoerd nadat we een reponse hebben ontvangen
         if (response.success) {
           this.bookCopyList = response.data;

--- a/src/app/add-copies/add-copies.component.ts
+++ b/src/app/add-copies/add-copies.component.ts
@@ -1,0 +1,72 @@
+import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { BookCopyService } from '../bookCopy.service';
+import { ReadBookDto } from '../../dto/ReadBookDto';
+import { ReadBookCopyDto } from '../../dto/ReadBookCopyDto';
+
+@Component({
+  selector: 'app-add-copies',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './add-copies.component.html',
+  styleUrl: './add-copies.component.scss'
+})
+export class AddCopiesComponent {
+
+  @Input() book: ReadBookDto | null = null;
+  @ViewChild('closeModal') closeModal?: ElementRef;
+  @ViewChild('openModal') openModal?: ElementRef;
+  addCopiesForm: FormGroup;
+  bookCopyList: ReadBookCopyDto[] = [];
+
+  constructor(private bookCopyService: BookCopyService, private formBuilder: FormBuilder) {
+    this.addCopiesForm = this.formBuilder.group({
+      states: new FormArray([], Validators.required),
+      nrCopies: new FormControl(''),
+    });
+  }
+
+  addCopies(nrCopies: number) {
+    for (let i = 0; i < nrCopies; i++) {
+      this.states.push(this.formBuilder.control('Nieuw', Validators.required));
+    }
+  }
+
+  removeCopy(index: number) {
+    this.states.removeAt(index);
+  }
+
+  resetForm() {
+    this.addCopiesForm.reset();
+    this.states.clear();
+  }
+
+  onSubmit(): void {
+    let dto = {
+      states:  this.states.value,
+      bookId: this.book?.id
+    }
+
+    if(confirm("Weet je zeker dat je " + this.states.length + " exemplaren van het boek: '" + this.book?.title + "' wilt toevoegen?")) {
+      this.bookCopyService.createBookCopy(dto).subscribe(response => {
+        // Dit wordt uitgevoerd nadat we een reponse hebben ontvangen
+        if (response.success) {
+          this.bookCopyList = response.data;
+          this.addCopiesForm.reset();
+          this.openModal?.nativeElement.click();
+        }
+        else {
+          alert(response.errors);
+        }
+      });
+      // Close the modal after the user confirmed.
+      this.closeModal?.nativeElement.click();
+    }
+  }
+
+  get states() {
+    return this.addCopiesForm.get('states') as FormArray;
+  }
+
+}

--- a/src/app/book-details/book-details.component.html
+++ b/src/app/book-details/book-details.component.html
@@ -19,7 +19,7 @@
         <th scope="row">Auteurs</th>
         <td>
           <span>
-            <ng-container *ngFor="let item of book.authors">
+            <ng-container *ngFor="let item of book?.authors">
               {{ item }} <br>
             </ng-container>
           </span>

--- a/src/app/book-form/book-form.component.html
+++ b/src/app/book-form/book-form.component.html
@@ -79,10 +79,10 @@
   </div>
 </div>
 
-<button type="button" #openModal class="btn btn-primary invisible" data-bs-toggle="modal" data-bs-target="#confirmModal1">
+<button type="button" #openModal class="btn btn-primary invisible" data-bs-toggle="modal" data-bs-target="#confirmModal">
 </button>
 
-<div class="modal fade" id="confirmModal1" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/src/app/book-form/book-form.component.html
+++ b/src/app/book-form/book-form.component.html
@@ -57,7 +57,13 @@
               <div *ngFor="let state of states.controls; let j=index">
                 <label for="bookCopy">Exemplaar {{j + 1}}</label>
                 <div formArrayName="states" class="input-group mb-3">
-                  <input [formControlName]="j" class="form-control" value="Nieuw" type="text" id="bookCopy">
+                  <select [formControlName]="j" class="form-control" id="bookCopy">
+                    <option value="NIEUW">Nieuw</option>
+                    <option value="GOED">Goed</option>
+                    <option value="GEMIDDELD">Gemiddeld</option>
+                    <option value="SLECHT">Slecht</option>
+                    <option value="ONBRUIKBAAR">Onbruikbaar</option>
+                  </select>
                   <div class="input-group-append">
                     <button class="btn btn-outline-secondary" id="minus" type="button" (click)="removeCopy(j)">-</button>
                   </div>
@@ -73,10 +79,10 @@
   </div>
 </div>
 
-<button type="button" #openModal class="btn btn-primary invisible" data-bs-toggle="modal" data-bs-target="#confirmModal">
+<button type="button" #openModal class="btn btn-primary invisible" data-bs-toggle="modal" data-bs-target="#confirmModal1">
 </button>
 
-<div class="modal fade" id="confirmModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="confirmModal1" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -85,7 +91,7 @@
       </div>
       <div class="modal-body">
         <div *ngFor="let bookcopy of bookCopyList">
-          <h5>Exemplaar {{bookcopy.wtid}}     Conditie: {{bookcopy.state}}</h5>
+          <h5>Exemplaar {{bookcopy.wtid}} Conditie: {{bookcopy.state}}</h5>
         </div>
       </div>
       <div class="modal-footer">

--- a/src/app/book-form/book-form.component.ts
+++ b/src/app/book-form/book-form.component.ts
@@ -43,7 +43,7 @@ export class BookFormComponent {
 
   addCopies(nrCopies: number) {
     for (let i = 0; i < nrCopies; i++) {
-      this.states.push(this.formBuilder.control('Nieuw', Validators.required));
+      this.states.push(this.formBuilder.control('NIEUW', Validators.required));
     }
   }
 
@@ -76,6 +76,7 @@ export class BookFormComponent {
         // Dit wordt uitgevoerd nadat we een reponse hebben ontvangen
         if (response.success) {
           this.bookCopyList = response.data;
+          console.log("bookCopyList", this.bookCopyList)
           this.bookForm.reset();
           this.onSave.emit();
           console.log(response.data);

--- a/src/app/book-form/book-form.component.ts
+++ b/src/app/book-form/book-form.component.ts
@@ -68,15 +68,12 @@ export class BookFormComponent {
     dto.authors = this.bookForm.value.authors;
     dto.categories = this.bookForm.value.categories;
     dto.states = this.bookForm.value.states;
-    console.log(dto);
 
     if(confirm("Weet je zeker dat je " + this.states.length + " exemplaren van het boek: '" + this.bookForm.value.title + "' wilt toevoegen?")) {
       this.bookService.addBook(dto).subscribe(response => {
-        console.log('response', response);
         // Dit wordt uitgevoerd nadat we een reponse hebben ontvangen
         if (response.success) {
           this.bookCopyList = response.data;
-          console.log("bookCopyList", this.bookCopyList)
           this.bookForm.reset();
           this.onSave.emit();
           console.log(response.data);

--- a/src/app/book/book.component.html
+++ b/src/app/book/book.component.html
@@ -18,6 +18,6 @@
       {{ item }}
     </h6>
     <p class="card-text">{{ book?.description }}</p>
-      <app-add-copies [book]="book"></app-add-copies>
+      <app-add-copies [bookAddCopy]="book"></app-add-copies>
     </div>
   </div>

--- a/src/app/book/book.component.html
+++ b/src/app/book/book.component.html
@@ -18,6 +18,6 @@
       {{ item }}
     </h6>
     <p class="card-text">{{ book?.description }}</p>
-      <app-add-copies [bookAddCopy]="book"></app-add-copies>
+      <app-add-copies *ngIf="hasAddBookCopyPermission()" [bookAddCopy]="book"></app-add-copies>
     </div>
   </div>

--- a/src/app/book/book.component.html
+++ b/src/app/book/book.component.html
@@ -1,33 +1,23 @@
-<!-- <button type="button" class="list-group-item list-group-item-action" (click)="gotoBookDetailPage(book)">
-    <div>
-        <img class="bookCover" src="assets/imgs/bookCover.png"/>
+<div class="card flex-row">
+  <img
+    class="card-img-left example-card-img-responsive"
+    src="assets/imgs/bookCover.png"
+  />
+  <div class="card-body">
+    <button
+      id="title"
+      class="card-title h5 h4-sm"
+      (click)="gotoBookDetailPage(book)"
+    >
+      {{ book?.title }}
+    </button>
+    <h6
+      class="card-subtitle mb-2 text-muted"
+      *ngFor="let item of book?.authors"
+    >
+      {{ item }}
+    </h6>
+    <p class="card-text">{{ book?.description }}</p>
+      <app-add-copies [book]="book"></app-add-copies>
     </div>
-    <h1>{{book?.title}}</h1>
-    <h2>{{book?.authors}}</h2><br>
-    <p>{{book?.description}}</p>
-</button> -->
-
-<!-- <div class="card">
-    <img class="card-img-left" src="assets/imgs/bookCover.png" alt="Card image cap">
-    <div class="card-body">
-      <h5 class="card-title">{{book?.title}}</h5>
-      <h6 class="card-subtitle mb-2 text-muted" *ngFor="let item of book?.authors">{{item}}<br></h6>
-      <p class="card-text">{{book?.description}}</p>
-    </div> -->
-
-    <div class="card flex-row"><img class="card-img-left example-card-img-responsive" src="assets/imgs/bookCover.png"/>
-        <div class="card-body">
-          <button id="title" class="card-title h5 h4-sm" (click)="gotoBookDetailPage(book)">{{book?.title}}</button>
-          <h6 class="card-subtitle mb-2 text-muted" *ngFor="let item of book?.authors">{{item}}</h6>
-          <p class="card-text">{{book?.description}}</p>
-          <div class="dropdown position-absolute top-0 end-0">
-            <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenu2" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Options
-            </button>
-            <div class="dropdown-menu" aria-labelledby="dropdownMenu2">
-              <button class="dropdown-item" type="button">Edit</button>
-              <button class="dropdown-item" type="button" (click)="deleteBook()">Delete</button>
-            </div>
-          </div>
-        </div>
-      </div>
+  </div>

--- a/src/app/book/book.component.ts
+++ b/src/app/book/book.component.ts
@@ -40,4 +40,10 @@ export class BookComponent {
     }
   }
 
+  hasAddBookCopyPermission() {
+    let role = localStorage.getItem('WT_ROLE');
+
+    return !!role && role == 'TRAINER';
+
+  }
 }

--- a/src/app/book/book.component.ts
+++ b/src/app/book/book.component.ts
@@ -4,11 +4,12 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { BookService } from '../book.service';
 import { CatalogueComponent } from '../catalogue/catalogue.component';
+import { AddCopiesComponent } from '../add-copies/add-copies.component';
 
 @Component({
   selector: 'app-book',
   standalone: true,
-  imports: [CommonModule, CatalogueComponent],
+  imports: [CommonModule, CatalogueComponent, AddCopiesComponent],
   templateUrl: './book.component.html',
   styleUrl: './book.component.scss'
 })

--- a/src/app/catalogue/catalogue.component.ts
+++ b/src/app/catalogue/catalogue.component.ts
@@ -4,11 +4,12 @@ import { ReadBookDto } from '../../dto/ReadBookDto';
 import { BookFormComponent } from '../book-form/book-form.component';
 import { BookService } from '../book.service';
 import { BookComponent } from '../book/book.component';
+import { AddCopiesComponent } from '../add-copies/add-copies.component';
 
 @Component({
   selector: 'app-catalogue',
   standalone: true,
-  imports: [NgFor, CommonModule, BookComponent, BookFormComponent],
+  imports: [NgFor, CommonModule, BookComponent, BookFormComponent, AddCopiesComponent],
   templateUrl: './catalogue.component.html',
   styleUrl: './catalogue.component.scss'
 })
@@ -24,7 +25,6 @@ export class CatalogueComponent implements OnInit {
 
   loadBooks() {
     this.bookService.getBooks(this.page).subscribe((response) => {
-      console.log(response);
       this.books = response.data.books;
     });
   }

--- a/src/dto/ReadBookCopyDto.ts
+++ b/src/dto/ReadBookCopyDto.ts
@@ -1,8 +1,8 @@
 export class ReadBookCopyDto {
     id?: number;
     wtid?: string;
-    isAvailable?: boolean;
+    // isAvailable?: boolean;
     state?: string;
-    bookId?: number;
+    // bookId?: number;
     available?: boolean;
 }

--- a/src/dto/ReadBookCopyDto.ts
+++ b/src/dto/ReadBookCopyDto.ts
@@ -1,8 +1,6 @@
 export class ReadBookCopyDto {
     id?: number;
     wtid?: string;
-    // isAvailable?: boolean;
     state?: string;
-    // bookId?: number;
     available?: boolean;
 }


### PR DESCRIPTION
Book copies can now be added for existing books in the catalog. The book components now each have a button to add these copies. 

The Trainer is prompted to add the number of copies they want to add. The default value of a new copy is "Nieuw" but this can be changed to 1 of 5 choices. After the Trainer clicks on "Opslaan", they should get a confirmation popup. After confirming, a modal with the added copies and their WTId's should be shown. 

After adding copies, the number of copies for the specified book is automatically changed.  

